### PR TITLE
Used args instead of query string

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -88,7 +88,7 @@ fi
     fastcgi_hide_header X-Runtime;
 
     location / {
-        try_files \$uri \$uri/ /index.php?\$query_string;
+        try_files \$uri \$uri/ /index.php\$is_args\$args;
         gzip_static on;
     }
     location ~ \.css {


### PR DESCRIPTION
args uses query string and php arguments supplied to the binary

$is_args is `?` or an empty string if args are supplied